### PR TITLE
Create unique ids for handlers

### DIFF
--- a/src/subscribr.js
+++ b/src/subscribr.js
@@ -8,7 +8,7 @@ module.exports = class Subscribr {
     on(eventId, callback) {
         if (!eventId || typeof eventId !== 'string') throw new Error('Invalid event identifier');
         if (!callback || typeof callback !== 'function') throw new Error('Invalid handler');
-        const handler = { callback, id: Date.now() };
+        const handler = { callback, id: uniqueId() };
         if (eventId === '*') {
             this._interceptors.push(handler);
             return createCommonDestroyer(handler.id, this._interceptors);
@@ -53,6 +53,12 @@ module.exports = class Subscribr {
         return [ ...this.interceptors, ...this.events ];
     }
 
+}
+
+let idCounter = 0;
+
+function uniqueId() {
+    return ++idCounter;
 }
 
 function createCommonDestroyer(handlerId, arr) {

--- a/src/subscribr.js
+++ b/src/subscribr.js
@@ -55,11 +55,10 @@ module.exports = class Subscribr {
 
 }
 
-let idCounter = 0;
-
-function uniqueId() {
-    return ++idCounter;
-}
+const uniqueId = (() => {
+  let idCounter = 0;
+  return () => ++idCounter;
+})();
 
 function createCommonDestroyer(handlerId, arr) {
     return () => arr.splice(arr.findIndex(handler => handler.id === handlerId), 1);

--- a/test/subscribr.spec.js
+++ b/test/subscribr.spec.js
@@ -40,6 +40,15 @@ describe('Class', () => {
                 _fn.should.Throw(Error);
             });
             it('should return a destroyer function', () => subscribr.on(mock.eventId, mock.handler).should.be.a(constants.fn));
+
+            it('should not create the same id for differents handlers', () => {
+                subscribr.on(mock.eventId, () => {});
+                subscribr.on(mock.eventId, () => {});
+                const idHandler1 = subscribr.events[0].handlers[0].id;
+                const idHandler2 = subscribr.events[0].handlers[1].id;
+
+                idHandler1.should.not.equal(idHandler2);
+            });
         });
 
         describe('one()', () => {


### PR DESCRIPTION
By using timestamp alone, if we add two handlers in a sequence,
we can end up with the same id. By using a method heavily inspired
in lodash#uniqueId, we can ensure that no ids will be the same.

Before:
<img width="265" alt="screen shot 2017-03-12 at 15 29 17" src="https://cloud.githubusercontent.com/assets/1131604/23832741/9c47e1a0-073b-11e7-992c-f1a7e28aee80.png">

After:
<img width="240" alt="screen shot 2017-03-12 at 15 31 37" src="https://cloud.githubusercontent.com/assets/1131604/23832746/a99cd31a-073b-11e7-9f7c-3efa4383d204.png">
